### PR TITLE
feat: migrate to Zig 0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Run tests
         run: zig build test

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zig_utils,
     .version = "0.6.1",
     .fingerprint = 0x6dc482caf73c4a75,
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
 
     .dependencies = .{
         .zspec = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,8 +6,8 @@
 
     .dependencies = .{
         .zspec = .{
-            .url = "https://github.com/apotema/zspec/archive/v0.7.0.tar.gz",
-            .hash = "zspec-0.7.0-jaKLbVqmAwDxLB7GYHuw354BQp7_uBSN9rSBUIfAx5xy",
+            .url = "git+https://github.com/apotema/zspec.git?ref=feat/zig-0.16-migration#42e1e69e31a6971c93e6807d29eabe30d9f46bd6",
+            .hash = "zspec-0.8.0-jaKLbe3SAwDRIFxFJbSQvz_lr9Xn-trRT9KR16I8C5_P",
         },
     },
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,8 +6,8 @@
 
     .dependencies = .{
         .zspec = .{
-            .url = "https://github.com/apotema/zspec/archive/v0.9.0.tar.gz",
-            .hash = "zspec-0.9.0-jaKLba73AwB5EK3YFyhpQ4roFBA_hhGbVvjSjur3KxZz",
+            .url = "https://github.com/apotema/zspec/archive/v0.9.1.tar.gz",
+            .hash = "zspec-0.9.1-jaKLbbX4AwBKANdetxzzWc3UTO0UY0lcJJzTagQHlt5K",
         },
     },
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,8 +6,8 @@
 
     .dependencies = .{
         .zspec = .{
-            .url = "git+https://github.com/apotema/zspec.git?ref=feat/zig-0.16-migration#42e1e69e31a6971c93e6807d29eabe30d9f46bd6",
-            .hash = "zspec-0.8.0-jaKLbe3SAwDRIFxFJbSQvz_lr9Xn-trRT9KR16I8C5_P",
+            .url = "https://github.com/apotema/zspec/archive/v0.9.0.tar.gz",
+            .hash = "zspec-0.9.0-jaKLba73AwB5EK3YFyhpQ4roFBA_hhGbVvjSjur3KxZz",
         },
     },
 

--- a/src/zon_coercion.zig
+++ b/src/zon_coercion.zig
@@ -258,55 +258,38 @@ fn MergedStructType(comptime BaseType: type, comptime OverridesType: type) type 
         }
     }
 
-    comptime var fields: [field_count]std.builtin.Type.StructField = undefined;
+    comptime var field_names: [field_count][]const u8 = undefined;
+    comptime var field_types: [field_count]type = undefined;
+    comptime var field_attrs: [field_count]std.builtin.Type.StructField.Attributes = undefined;
     comptime var i = 0;
 
     inline for (base_fields) |bf| {
         if (@hasField(OverridesType, bf.name)) {
             inline for (override_fields) |of| {
                 if (comptime std.mem.eql(u8, of.name, bf.name)) {
-                    fields[i] = .{
-                        .name = bf.name,
-                        .type = of.type,
-                        .default_value_ptr = null,
-                        .is_comptime = false,
-                        .alignment = @alignOf(of.type),
-                    };
+                    field_names[i] = bf.name;
+                    field_types[i] = of.type;
+                    field_attrs[i] = .{ .@"align" = @alignOf(of.type) };
                 }
             }
         } else {
-            fields[i] = .{
-                .name = bf.name,
-                .type = bf.type,
-                .default_value_ptr = null,
-                .is_comptime = false,
-                .alignment = @alignOf(bf.type),
-            };
+            field_names[i] = bf.name;
+            field_types[i] = bf.type;
+            field_attrs[i] = .{ .@"align" = @alignOf(bf.type) };
         }
         i += 1;
     }
 
     inline for (override_fields) |of| {
         if (!@hasField(BaseType, of.name)) {
-            fields[i] = .{
-                .name = of.name,
-                .type = of.type,
-                .default_value_ptr = null,
-                .is_comptime = false,
-                .alignment = @alignOf(of.type),
-            };
+            field_names[i] = of.name;
+            field_types[i] = of.type;
+            field_attrs[i] = .{ .@"align" = @alignOf(of.type) };
             i += 1;
         }
     }
 
-    return @Type(.{
-        .@"struct" = .{
-            .layout = .auto,
-            .fields = &fields,
-            .decls = &.{},
-            .is_tuple = false,
-        },
-    });
+    return @Struct(.auto, null, &field_names, &field_types, &field_attrs);
 }
 
 /// Check if a struct type has any fields

--- a/tests/root.zig
+++ b/tests/root.zig
@@ -12,5 +12,5 @@ pub const heuristics_test = @import("heuristics_test.zig");
 pub const zon_coercion_test = @import("zon_coercion_test.zig");
 
 test {
-    std.testing.refAllDeclsRecursive(@This());
+    std.testing.refAllDecls(@This());
 }


### PR DESCRIPTION
## Summary
- Bumps `minimum_zig_version` to 0.16.0
- `@Type(.{ .@"struct" })` → `@Struct(...)` in `zon_coercion.zig` (with `StructField.Attributes` reshaping)
- `std.testing.refAllDeclsRecursive` → `refAllDecls`
- Bumps zspec to apotema/zspec 0.16 branch

## Status
- `zig build`: ✅ PASS
- `zig build test`: ✅ PASS