### PR TITLE
fix(tests): recursively collect nested zspec tests (#14)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zig_utils,
-    .version = "0.7.2",
+    .version = "0.7.3",
     .fingerprint = 0x6dc482caf73c4a75,
     .minimum_zig_version = "0.16.0",
 

--- a/src/a_star.zig
+++ b/src/a_star.zig
@@ -227,15 +227,15 @@ pub fn AStar(comptime WeightType: type) type {
             var closed_set = try std.DynamicBitSet.initEmpty(self.allocator, n);
             defer closed_set.deinit();
 
-            var open_set = std.PriorityQueue(PQNode, void, PQNode.compare).init(self.allocator, {});
-            defer open_set.deinit();
+            var open_set = std.PriorityQueue(PQNode, void, PQNode.compare).initContext({});
+            defer open_set.deinit(self.allocator);
 
             // Initialize source
             g_score[source] = 0;
             const h = self.calculateHeuristic(source, dest);
-            try open_set.add(.{ .vertex = source, .f_score = h });
+            try open_set.push(self.allocator, .{ .vertex = source, .f_score = h });
 
-            while (open_set.removeOrNull()) |current| {
+            while (open_set.pop()) |current| {
                 if (current.vertex == dest) {
                     // Reconstruct path
                     var node = dest;
@@ -273,7 +273,7 @@ pub fn AStar(comptime WeightType: type) type {
                         g_score[edge.to] = tentative_g;
 
                         const f = @as(f32, @floatFromInt(tentative_g)) + self.calculateHeuristic(edge.to, dest);
-                        try open_set.add(.{ .vertex = edge.to, .f_score = f });
+                        try open_set.push(self.allocator, .{ .vertex = edge.to, .f_score = f });
                     }
                 }
             }

--- a/src/z_index_buckets.zig
+++ b/src/z_index_buckets.zig
@@ -38,7 +38,7 @@ pub fn ZIndexBuckets(comptime T: type, comptime ZIndexType: type) type {
 
         pub fn init(allocator: std.mem.Allocator) Self {
             return Self{
-                .buckets = [_]Bucket{.{}} ** bucket_count,
+                .buckets = [_]Bucket{.empty} ** bucket_count,
                 .allocator = allocator,
                 .total_count = 0,
             };

--- a/tests/floyd_warshall_optimized_test.zig
+++ b/tests/floyd_warshall_optimized_test.zig
@@ -115,7 +115,7 @@ pub const FloydWarshallOptimizedSpec = struct {
 
             fw.generate();
 
-            var path = std.ArrayListUnmanaged(u32){};
+            var path = std.ArrayListUnmanaged(u32).empty;
             defer path.deinit(allocator);
 
             try fw.setPathWithMappingUnmanaged(allocator, &path, 10, 40);
@@ -152,7 +152,7 @@ pub const FloydWarshallOptimizedSpec = struct {
             fw.next[idx_a * size + idx_d] = idx_b; // from 10 toward 40 -> 20
             fw.next[idx_b * size + idx_d] = idx_a; // from 20 toward 40 -> back to 10
 
-            var path = std.ArrayListUnmanaged(u32){};
+            var path = std.ArrayListUnmanaged(u32).empty;
             defer path.deinit(allocator);
 
             // Must TERMINATE with an error, not hang.

--- a/tests/root.zig
+++ b/tests/root.zig
@@ -12,8 +12,31 @@ pub const a_star_test = @import("a_star_test.zig");
 pub const heuristics_test = @import("heuristics_test.zig");
 pub const zon_coercion_test = @import("zon_coercion_test.zig");
 
+// std's `refAllDecls` is ONE level deep — it references the imported test
+// structs above, but NOT the `pub const FooSpec = struct { pub const group =
+// struct { test "..." {} } }` groups nested inside them. Under Zig 0.16 a
+// `test` block is only collected into the test binary once its containing
+// struct is semantically analyzed, so every doubly-nested zspec test was
+// silently never run, and `zig build test` passed even with a failing
+// assertion (#14). Recurse into every nested container type so each group
+// struct is analyzed and its tests get collected. (Zig 0.16 dropped
+// `std.testing.refAllDeclsRecursive`, hence the local copy.)
+fn refAllDeclsRecursive(comptime T: type) void {
+    if (!@import("builtin").is_test) return;
+    inline for (comptime std.meta.declarations(T)) |decl| {
+        const field = @field(T, decl.name);
+        if (@TypeOf(field) == type) {
+            switch (@typeInfo(field)) {
+                .@"struct", .@"enum", .@"union", .@"opaque" => refAllDeclsRecursive(field),
+                else => {},
+            }
+        }
+        _ = &@field(T, decl.name);
+    }
+}
+
 test {
-    std.testing.refAllDecls(@This());
+    refAllDeclsRecursive(@This());
 }
 
 // Regression for #13 — kept at the test ROOT (top-level) on purpose: the


### PR DESCRIPTION
Closes #14. One-level refAllDecls meant doubly-nested zspec tests (FooSpec → group → test) were never compiled or run under Zig 0.16 — zig build test ran only the root #13 test and passed even when broken. Added refAllDeclsRecursive; surfaced + fixed 0.16-stale library code it masked (a_star PriorityQueue → unmanaged initContext/push/pop/deinit(allocator); z_index_buckets + a floyd test ArrayListUnmanaged → .empty). **1 → 91 tests run, all green**; force-failing a nested test now fails the build (verified). v0.7.2 → 0.7.3.